### PR TITLE
Feat/workflow update only description button

### DIFF
--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -118,7 +118,7 @@ jobs:
           generate_release_notes: false
 
   generate-matrix:
-    if: ${{ github.event.inputs.only_description == false }}
+    if: ${{ github.event.inputs.only_description != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -21,6 +21,10 @@ on:
         type: string
         description: Version to build (if single_version is true)
         default: ''
+      only_description:
+        type: boolean
+        description: Only update the description on Modrinth
+        default: false
 
 permissions:
   contents: write
@@ -113,6 +117,7 @@ jobs:
           generate_release_notes: false
 
   generate-matrix:
+    if: ${{ github.event.inputs.only_description != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -171,7 +176,6 @@ jobs:
 
   update-description:
     runs-on: ubuntu-latest
-    needs: release
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   release:
-    if: ${{ github.event.inputs.only_description != 'true' }}
+    if: ${{ !github.event.inputs.only_description }}
     runs-on: ubuntu-latest
     outputs:
       TAG: ${{ steps.tag.outputs.TAG }}

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -192,4 +192,4 @@ jobs:
       - name: Update Description
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
-        run: ./gradlew modrinthSyncBody
+        run: ./gradlew modrinthSyncBody -Pdebug=${{ github.event.inputs.debug }}

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -35,6 +35,7 @@ env:
 
 jobs:
   release:
+    if: ${{ github.event.inputs.only_description != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       TAG: ${{ steps.tag.outputs.TAG }}

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   release:
-    if: ${{ github.event.inputs.only_description == false }}
+    if: ${{ github.event.inputs.only_description != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       TAG: ${{ steps.tag.outputs.TAG }}

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -32,10 +32,11 @@ permissions:
 env:
   DEBUG: ${{ github.event.inputs.debug }}
   VERSION_TYPE: ${{ github.event.inputs.version_type }}
+  ONLY_DESCRIPTION: ${{ github.event.inputs.only_description == true }}
 
 jobs:
   release:
-    if: ${{ github.event.inputs.only_description != 'true' }}
+    if: ${{ ONLY_DESCRIPTION == false }}
     runs-on: ubuntu-latest
     outputs:
       TAG: ${{ steps.tag.outputs.TAG }}
@@ -118,7 +119,7 @@ jobs:
           generate_release_notes: false
 
   generate-matrix:
-    if: ${{ github.event.inputs.only_description != 'true' }}
+    if: ${{ ONLY_DESCRIPTION == false }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -118,7 +118,7 @@ jobs:
           generate_release_notes: false
 
   generate-matrix:
-    if: ${{ github.event.inputs.only_description != 'true' }}
+    if: ${{ !github.event.inputs.only_description }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -32,11 +32,10 @@ permissions:
 env:
   DEBUG: ${{ github.event.inputs.debug }}
   VERSION_TYPE: ${{ github.event.inputs.version_type }}
-  ONLY_DESCRIPTION: ${{ github.event.inputs.only_description == true }}
 
 jobs:
   release:
-    if: ${{ ONLY_DESCRIPTION == false }}
+    if: ${{ github.event.inputs.only_description == false }}
     runs-on: ubuntu-latest
     outputs:
       TAG: ${{ steps.tag.outputs.TAG }}
@@ -119,7 +118,7 @@ jobs:
           generate_release_notes: false
 
   generate-matrix:
-    if: ${{ ONLY_DESCRIPTION == false }}
+    if: ${{ github.event.inputs.only_description == false }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
This pull request introduces a new input parameter, `only_description`, to the `.github/workflows/publish_test.yml` file, allowing for workflows that only update the description on Modrinth without triggering a full release process. It also adjusts the workflow logic to respect this new parameter.

### Additions for `only_description` functionality:
* Added a new input parameter `only_description` to the workflow, which is a boolean flag used to determine if only the description should be updated on Modrinth (`.github/workflows/publish_test.yml`).

### Workflow logic updates:
* Added conditional checks (`if` statements) to the `release` and `generate-matrix` jobs to skip execution when `only_description` is set to `true` (`.github/workflows/publish_test.yml`). [[1]](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661R38) [[2]](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661R121)
* Removed the dependency on the `release` job for the `update-description` job, allowing it to run independently when `only_description` is `true` (`.github/workflows/publish_test.yml`).