### PR TITLE
fix(publish_test): add debug option to modrinthSyncBody command

### DIFF
--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -192,4 +192,4 @@ jobs:
       - name: Update Description
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
-        run: ./gradlew modrinthSyncBody
+        run: ./gradlew modrinthSyncBody -Pdebug=${{ github.event.inputs.debug }}


### PR DESCRIPTION
This pull request introduces a minor update to the `jobs:` section of the `.github/workflows/publish_test.yml` file. The change adds a `-Pdebug` parameter to the `modrinthSyncBody` Gradle command, enabling the use of a `debug` input from the GitHub event.