### PR TITLE
fix(publish_test): correct condition for only description input

### DIFF
--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   release:
-    if: ${{ !github.event.inputs.only_description }}
+    if: ${{ github.event.inputs.only_description != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       TAG: ${{ steps.tag.outputs.TAG }}
@@ -118,7 +118,7 @@ jobs:
           generate_release_notes: false
 
   generate-matrix:
-    if: ${{ !github.event.inputs.only_description }}
+    if: ${{ github.event.inputs.only_description != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
This pull request updates conditional checks in the `.github/workflows/publish_test.yml` file to improve clarity and correctness by explicitly comparing the `only_description` input to the string `'true'`.

### Workflow condition updates:

* Updated the `if` condition in the `release` job to explicitly compare `github.event.inputs.only_description` with `'true'` instead of relying on negation. (`.github/workflows/publish_test.yml`, [.github/workflows/publish_test.ymlL38-R38](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661L38-R38))
* Updated the `if` condition in the `generate-matrix` job to explicitly compare `github.event.inputs.only_description` with `'true'` instead of relying on negation. (`.github/workflows/publish_test.yml`, [.github/workflows/publish_test.ymlL121-R121](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661L121-R121))