### PR TITLE
feat(build): add versionType to BuildInfo and log output

### DIFF
--- a/src/main/java-templates/modtemplate/BuildInfo.java.peb
+++ b/src/main/java-templates/modtemplate/BuildInfo.java.peb
@@ -19,4 +19,5 @@ public final class BuildInfo {
     public static String version() { return VERSION; }
 
     public static String mcVersion() { return MC_VERSION; }
+    public static String versionType() { return VERSION_TYPE; }
 }

--- a/src/main/java/modtemplate/ClientModTemplate.java
+++ b/src/main/java/modtemplate/ClientModTemplate.java
@@ -23,7 +23,7 @@ public class ClientModTemplate implements ClientModInitializer {
     public void onInitializeClient() {
         LOGGER.info("Hello Fabric world!");
 
-        LOGGER.info("BuildInfo: version={}, group={}, artifact={}, commit={}, branch={}, targetMCVersion={}", BuildInfo.version(), BuildInfo.group(), BuildInfo.artifact(), BuildInfo.commit(), BuildInfo.branch(), BuildInfo.mcVersion());
+        LOGGER.info("BuildInfo: version={}, group={}, artifact={}, commit={}, branch={}, targetMCVersion={}, versionType={}", BuildInfo.version(), BuildInfo.group(), BuildInfo.artifact(), BuildInfo.commit(), BuildInfo.branch(), BuildInfo.mcVersion(), BuildInfo.versionType());
 
         #if MC_VER >= MC_1_20_5
         PayloadTypeRegistry.playC2S().register(HelloPacket.ID, HelloPacket.STREAM_CODEC);

--- a/src/main/java/modtemplate/ServerModTemplate.java
+++ b/src/main/java/modtemplate/ServerModTemplate.java
@@ -19,7 +19,7 @@ public class ServerModTemplate implements DedicatedServerModInitializer {
     public void onInitializeServer() {
         LOGGER.info("Hello Fabric server world!");
 
-        LOGGER.info("BuildInfo: version={}, group={}, artifact={}, commit={}, branch={}, targetMCVersion={}", BuildInfo.version(), BuildInfo.group(), BuildInfo.artifact(), BuildInfo.commit(), BuildInfo.branch(), BuildInfo.mcVersion());
+        LOGGER.info("BuildInfo: version={}, group={}, artifact={}, commit={}, branch={}, targetMCVersion={}, versionType={}", BuildInfo.version(), BuildInfo.group(), BuildInfo.artifact(), BuildInfo.commit(), BuildInfo.branch(), BuildInfo.mcVersion(), BuildInfo.versionType());
          #if MC_VER >= MC_1_20_5
         PayloadTypeRegistry.playC2S().register(HelloPacket.ID, HelloPacket.STREAM_CODEC);
         PayloadTypeRegistry.playS2C().register(HelloPacket.ID, HelloPacket.STREAM_CODEC);


### PR DESCRIPTION
This pull request introduces a new `versionType` field to the `BuildInfo` class and updates logging statements in both client and server initializers to include this new field. These changes enhance the logging output by providing additional build metadata.

### Enhancements to logging:

* [`src/main/java-templates/modtemplate/BuildInfo.java.peb`](diffhunk://#diff-087d72881596872e1d1d055b4c39b3ae981ab8b7bc5ec0a26370d7d3ed03d621R22): Added a new method `versionType()` to expose the `VERSION_TYPE` field.
* [`src/main/java/modtemplate/ClientModTemplate.java`](diffhunk://#diff-e253ad8bee8e288f49e44bc48814f3b6917700921fd1eb23d7f92efaed24983aL26-R26): Updated the logging statement in `onInitializeClient` to include the `versionType` field from `BuildInfo`.
* [`src/main/java/modtemplate/ServerModTemplate.java`](diffhunk://#diff-3f4ce300f87e0ffd15d98cb033bc2abcda3ba5497ff28d2cc4152768d2056da6L22-R22): Updated the logging statement in `onInitializeServer` to include the `versionType` field from `BuildInfo`.