### PR TITLE
Feat/tags with branch name

### DIFF
--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -52,19 +52,24 @@ jobs:
           DATE=$(date +'%Y.%m.%d')
           TAGS=$(git tag --list "${DATE}*")
           echo "Existing tags: $TAGS"
-          
+      
           if [ -z "$TAGS" ]; then
-            VERSION="$DATE"
+          VERSION="$DATE"
           else
-            SUFFIXES=$(echo "$TAGS" | sed -n "s/^$DATE\([a-z]\)$/\1/p")
-            NEXT_SUFFIX="b"
-            if [ -n "$SUFFIXES" ]; then
-              LAST_SUFFIX=$(echo "$SUFFIXES" | sort | tail -n1)
-              NEXT_SUFFIX=$(printf "\\$(printf '%03o' $(( $(printf '%d' "'$LAST_SUFFIX") + 1 )) )")
-            fi
-            VERSION="${DATE}${NEXT_SUFFIX}"
+          SUFFIXES=$(echo "$TAGS" | sed -n "s/^$DATE\([a-z]\).*$/\1/p")
+          NEXT_SUFFIX="b"
+          if [ -n "$SUFFIXES" ]; then
+          LAST_SUFFIX=$(echo "$SUFFIXES" | sort | tail -n1)
+          NEXT_SUFFIX=$(printf "\\$(printf '%03o' $(( $(printf '%d' "'$LAST_SUFFIX") + 1 )) )")
           fi
-          
+          VERSION="${DATE}${NEXT_SUFFIX}"
+          fi
+      
+          BRANCH="${GITHUB_REF##*/}"
+          if [ "$BRANCH" != "main" ]; then
+          VERSION="${VERSION}-${BRANCH}"
+          fi
+      
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "$VERSION"

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   release:
-    if: ${{ !github.event.inputs.only_description }}
+    if: ${{ github.event.inputs.only_description != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       TAG: ${{ steps.tag.outputs.TAG }}
@@ -123,7 +123,7 @@ jobs:
           generate_release_notes: false
 
   generate-matrix:
-    if: ${{ !github.event.inputs.only_description }}
+    if: ${{ github.event.inputs.only_description != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/build.main.gradle
+++ b/build.main.gradle
@@ -14,6 +14,10 @@ base {
     archivesName = project.archives_base_name
 }
 
+def isDebugMode() {
+    return System.getenv("DEBUG")?.toBoolean() ?: false
+}
+
 // -------------------- VERSION HANDLING --------------------
 def generateMcVersionMacros(List<String> versions, int selectedIndex) {
     def sb = new StringBuilder("# DO NOT TOUCH THIS FILE, it is handled by the build script\n")
@@ -350,8 +354,7 @@ println "🔄 Changelog:\n${changelogText}"
 
 modrinth {
     println "🔗 Configuring Modrinth upload..."
-    println "Debug mode: ${project.hasProperty("debug") && project.debug == "true"} (${project.property("debug")})"
-    debugMode = project.hasProperty("debug") && project.debug == "true"
+    debugMode = isDebugMode()
     syncBodyFrom = rootProject.file("README.md").text
     token = System.getenv("MODRINTH_TOKEN")
     projectId = project.modrinth_projectId

--- a/build.main.gradle
+++ b/build.main.gradle
@@ -349,7 +349,7 @@ def changelogText = changelogFile.exists() ? changelogFile.text : "No changelog 
 println "🔄 Changelog:\n${changelogText}"
 
 modrinth {
-    debugMode = project.hasProperty("debug") ? project.debug : false
+    debugMode = project.hasProperty("debug") && project.debug == "true"
     syncBodyFrom = rootProject.file("README.md").text
     token = System.getenv("MODRINTH_TOKEN")
     projectId = project.modrinth_projectId

--- a/build.main.gradle
+++ b/build.main.gradle
@@ -349,7 +349,7 @@ def changelogText = changelogFile.exists() ? changelogFile.text : "No changelog 
 println "🔄 Changelog:\n${changelogText}"
 
 modrinth {
-    debugMode = project.hasProperty("debug") ?: false
+    debugMode = project.hasProperty("debug") ? project.debug : false
     syncBodyFrom = rootProject.file("README.md").text
     token = System.getenv("MODRINTH_TOKEN")
     projectId = project.modrinth_projectId

--- a/build.main.gradle
+++ b/build.main.gradle
@@ -349,6 +349,8 @@ def changelogText = changelogFile.exists() ? changelogFile.text : "No changelog 
 println "🔄 Changelog:\n${changelogText}"
 
 modrinth {
+    println "🔗 Configuring Modrinth upload..."
+    println "Debug mode: ${project.hasProperty("debug") && project.debug == "true"} (${project.property("debug")})"
     debugMode = project.hasProperty("debug") && project.debug == "true"
     syncBodyFrom = rootProject.file("README.md").text
     token = System.getenv("MODRINTH_TOKEN")


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow and the Gradle build script to improve functionality and maintainability. Key changes include refining conditional logic in workflows, enhancing version tagging for non-main branches, and introducing a utility function to handle debug mode in the build script.

### Workflow improvements:
* [`.github/workflows/publish_test.yml`](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661L38-R38): Updated conditional statements to explicitly compare `only_description` input against the string `'true'` for better clarity and correctness. [[1]](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661L38-R38) [[2]](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661L121-R126)
* [`.github/workflows/publish_test.yml`](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661R68-R72): Enhanced version tagging to include the branch name as a suffix when the branch is not `main`.
* [`.github/workflows/publish_test.yml`](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661L59-R59): Fixed a `sed` command to correctly handle tags with additional characters after the suffix.

### Build script enhancements:
* [`build.main.gradle`](diffhunk://#diff-461f9b6f8f740bb3b325c6016627bb73ca523294ebc33f9cee92db78088fc0b6R17-R20): Added a reusable `isDebugMode` function to determine debug mode based on the `DEBUG` environment variable, improving code readability and reusability.
* [`build.main.gradle`](diffhunk://#diff-461f9b6f8f740bb3b325c6016627bb73ca523294ebc33f9cee92db78088fc0b6L352-R357): Replaced inline debug mode logic with the new `isDebugMode` function in the Modrinth configuration block.