### PR TITLE
refactor(publish_test): remove single_version option and simplify ver…

### DIFF
--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -13,13 +13,9 @@ on:
         type: boolean
         description: Debug build
         default: false
-      single_version:
-        type: boolean
-        description: Single version build
-        default: false
       version:
         type: string
-        description: Version to build (if single_version is true)
+        description: Version to build (only for single version builds)
         default: ''
       only_description:
         type: boolean
@@ -143,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mc_version: ${{ github.event.inputs.single_version == 'true' && github.event.inputs.version != '' && fromJson(format('["{0}"]', github.event.inputs.version)) || fromJson(needs.generate-matrix.outputs.matrix) }}
+        mc_version: ${{ github.event.inputs.version != '' && fromJson(format('["{0}"]', github.event.inputs.version)) || fromJson(needs.generate-matrix.outputs.matrix) }}
     name: Build ${{ matrix.mc_version }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This pull request introduces a new `versionType` property in the `BuildInfo` class and updates the logging statements in both the client and server initializers to include this property. These changes enhance the build metadata and improve logging for better traceability.

### Enhancements to Build Metadata:

* [`src/main/java-templates/modtemplate/BuildInfo.java.peb`](diffhunk://#diff-087d72881596872e1d1d055b4c39b3ae981ab8b7bc5ec0a26370d7d3ed03d621R22): Added a new static method `versionType()` to expose the `VERSION_TYPE` property.

### Logging Improvements:

* [`src/main/java/modtemplate/ClientModTemplate.java`](diffhunk://#diff-e253ad8bee8e288f49e44bc48814f3b6917700921fd1eb23d7f92efaed24983aL26-R26): Updated the logging statement in `onInitializeClient()` to include the `versionType` property from `BuildInfo`.
* [`src/main/java/modtemplate/ServerModTemplate.java`](diffhunk://#diff-3f4ce300f87e0ffd15d98cb033bc2abcda3ba5497ff28d2cc4152768d2056da6L22-R22): Updated the logging statement in `onInitializeServer()` to include the `versionType` property from `BuildInfo`.
This pull request simplifies the workflow configuration in `.github/workflows/publish_test.yml` by removing the `single_version` input and updating related logic to streamline the build process for single version builds.

### Workflow configuration updates:

* Removed the `single_version` input parameter and updated the description of the `version` input to clarify its use for single version builds. (`[.github/workflows/publish_test.ymlL16-R18](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661L16-R18)`)
* Simplified the matrix generation logic in the `jobs` section by removing the dependency on the `single_version` input, relying solely on the presence of the `version` input for single version builds. (`[.github/workflows/publish_test.ymlL146-R142](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661L146-R142)`)