### PR TITLE
Feat/action cleanup

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -1,38 +1,30 @@
 {
-  "template": "#{{CHANGELOG}}",
-  "commit": "- {{messageTitle}} ({{author}})",
+  "pr_template": "- ${{TITLE}} (#${{NUMBER}})",
   "categories": [
     {
-      "title": "🚀 Features",
-      "labels": ["feature", "enhancement", "feat"]
+      "title": "## 🚀 Features",
+      "labels": ["enhancement", "feature"]
     },
     {
-      "title": "🐛 Bug Fixes",
+      "title": "## 🛠️ Minor Changes",
+      "labels": ["change"]
+    },
+    {
+      "title": "## 🔎 Breaking Changes",
+      "labels": ["breaking"]
+    },
+    {
+      "title": "## 🐛 Fixes",
       "labels": ["bug", "fix"]
     },
     {
-      "title": "🧰 Maintenance",
-      "labels": ["chore", "maintenance", "refactor"]
+      "title": "## 📄 Documentation",
+      "labels": ["documentation"]
     },
     {
-      "title": "📚 Documentation",
-      "labels": ["documentation", "docs"]
-    },
-    {
-      "title": "🎉 Other",
-      "labels": []
+      "title": "## 🔗 Dependency Updates",
+      "labels": ["dependency"]
     }
   ],
-  "label_extractor": [
-    {
-      "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
-      "on_property": "title",
-      "target": "$1"
-    }
-  ],
-  "sort": {
-    "commits": "date-desc"
-  },
-  "pr_template": "- {{title}} (#{{id}} by @{{author}})"
+  "template": "${{CATEGORIZED_COUNT}} changes since ${{FROM_TAG}}\n\n${{CHANGELOG}}"
 }
-

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -97,6 +97,8 @@ jobs:
       - name: Generate changelog
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: .github/changelog-config.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish_test.yml
+++ b/.github/workflows/publish_test.yml
@@ -13,13 +13,9 @@ on:
         type: boolean
         description: Debug build
         default: false
-      single_version:
-        type: boolean
-        description: Single version build
-        default: false
       version:
         type: string
-        description: Version to build (if single_version is true)
+        description: Version to build (only for single version builds)
         default: ''
       only_description:
         type: boolean
@@ -143,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mc_version: ${{ github.event.inputs.single_version == 'true' && github.event.inputs.version != '' && fromJson(format('["{0}"]', github.event.inputs.version)) || fromJson(needs.generate-matrix.outputs.matrix) }}
+        mc_version: ${{ github.event.inputs.version != '' && fromJson(format('["{0}"]', github.event.inputs.version)) || fromJson(needs.generate-matrix.outputs.matrix) }}
     name: Build ${{ matrix.mc_version }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This pull request introduces updates to the changelog configuration and workflow files to improve changelog generation and simplify version handling in workflows. Key changes include restructuring the changelog categories, modifying workflow inputs, and refining the matrix generation logic.

### Changelog Configuration Updates:
* [`.github/changelog-configuration.json`](diffhunk://#diff-a252f7173526e238c1ca4f14ee8a6a5d9bfd717e399884fb60b36ae2ce6633f3L2-L38): Updated the changelog template and restructured categories to use clearer titles and labels, including changes to "Features," "Fixes," and new categories like "Breaking Changes" and "Dependency Updates."

### Workflow Input Modifications:
* [`.github/workflows/publish_test.yml`](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661L16-R18): Removed the `single_version` input and clarified the description for the `version` input to specify its use for single-version builds.

### Workflow Logic and Configuration Enhancements:
* [`.github/workflows/publish_test.yml`](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661R100-R101): Added a reference to the new changelog configuration file in the "Generate changelog" step.
* [`.github/workflows/publish_test.yml`](diffhunk://#diff-95cc124d815ebcff395a69e3e5dacfa00738be48cc5e5828ee82d6d8f98dd661L146-R144): Simplified the matrix generation logic by removing the dependency on the `single_version` input and directly checking the `version` input.