### PR TITLE
Check GitHub credentials before API calls

### DIFF
--- a/update-readme-badges.py
+++ b/update-readme-badges.py
@@ -18,10 +18,10 @@ if not GITHUB_TOKEN:
     missing.append("GITHUB_TOKEN")
 if missing:
     message = f"Missing environment variables: {', '.join(missing)}"
-    if not os.environ.get("CI"):
-        logging.warning(message)
-    else:
+    if os.environ.get("CI"):
         print(message, file=sys.stderr)
+    else:
+        logging.warning(message)
     sys.exit(1)
 
 if len(sys.argv) < 2:


### PR DESCRIPTION
## Summary
- ensure update-readme-badges.py validates GITHUB_REPOSITORY and GITHUB_TOKEN before hitting the API
- warn when credentials missing outside CI

## Testing
- `python -m py_compile update-readme-badges.py`
- `python update-readme-badges.py '[]'` *(fails: Missing environment variables: GITHUB_REPOSITORY, GITHUB_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_6899e54093a0832db9b9c098e37beb4b