### PR TITLE
Vendor build.main.gradle and document update procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ Clone the repository and invoke the build:
 
 The resulting mod jar will be placed in `build/libs`.
 
+## Updating build.main.gradle
+
+The file `build.main.gradle` is vendored from the upstream [uebliche/mod-template](https://github.com/uebliche/mod-template) repository.
+To update it to the latest version, run:
+
+```bash
+curl -L https://raw.githubusercontent.com/uebliche/mod-template/main/build.main.gradle -o build.main.gradle
+```
+
+Commit the refreshed file to keep the template in sync with upstream.
+
 ## Customisation
 
 Adjust the mod id, name and other metadata in `gradle.properties`.

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,4 @@ plugins {
     alias(libs.plugins.blossom)
 }
 
-// Local build.gradle file
-//apply from: 'build.main.gradle'
-apply from: 'https://raw.githubusercontent.com/uebliche/mod-template/main/build.main.gradle'
+apply from: 'build.main.gradle'


### PR DESCRIPTION
## Summary
- Apply vendored `build.main.gradle` locally instead of fetching from remote
- Describe how to update the vendored `build.main.gradle`

## Testing
- `bash gradlew help` *(fails: Plugin [id: 'fabric-loom', version: '1.11-SNAPSHOT'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899e54772e8832db23139fa85228a60