### PR TITLE
chore: update GitHub Actions versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       NOTES: ${{ steps.get_release_notes.outputs.notes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -119,7 +119,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Build loader/version matrix
         id: set-matrix
         run: |
@@ -191,9 +191,9 @@ jobs:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     name: Build ${{ matrix.loader }} ${{ matrix.mcVersion }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
@@ -240,10 +240,10 @@ jobs:
   update-description:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
           DATE=$(date +'%Y.%m.%d')
           TAGS=$(git tag --list "${DATE}*")
           echo "Existing tags: $TAGS"
-          
+
           if [ -z "$TAGS" ]; then
           VERSION="$DATE"
           else
@@ -62,12 +62,12 @@ jobs:
           fi
           VERSION="${DATE}${NEXT_SUFFIX}"
           fi
-          
+
           BRANCH="${GITHUB_REF##*/}"
           if [ "$BRANCH" != "main" ]; then
           VERSION="${VERSION}-${BRANCH}"
           fi
-          
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "$VERSION"
@@ -193,6 +193,11 @@ jobs:
     name: Build ${{ matrix.loader }} ${{ matrix.mcVersion }}
     steps:
       - uses: actions/checkout@v6
+      - name: Checkout mcmeta
+        uses: actions/checkout@v6
+        with:
+          repository: uebliche/mcmeta
+          path: .mcmeta
       - name: Set up Java
         uses: actions/setup-java@v5
         with:
@@ -210,6 +215,7 @@ jobs:
           VERSION_TYPE: ${{ github.event.inputs.version_type }}
           DEBUG_FLAG: ${{ github.event.inputs.debug }}
           EXTRA_ARGS: ${{ join(matrix.args, ' ') }}
+          MCMETA_PLUGIN_PATH: ${{ github.workspace }}/.mcmeta/gradle-plugin
         run: |
           set -euo pipefail
           if [ "$LOADER" = "fabric" ]; then
@@ -235,13 +241,20 @@ jobs:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
           GITHUB_SHA: ${{ github.sha }}
           CHANGELOG: ${{ needs.release.outputs.notes }}
+          MCMETA_PLUGIN_PATH: ${{ github.workspace }}/.mcmeta/gradle-plugin
         run: |
-          ./gradlew :loader-fabric:modrinth -PmcVersion=${{ matrix.mcVersion }} -Ptag=${{ needs.release.outputs.TAG }} -Pversion_type=${{ github.event.inputs.version_type }} -Pdebug=${{ github.event.inputs.debug }} ${{ join(matrix.args, ' ') }}
+          ./gradlew -Dorg.gradle.java.home="$JAVA_HOME" :loader-fabric:modrinth -PmcVersion=${{ matrix.mcVersion }} -Ptag=${{ needs.release.outputs.TAG }} -Pversion_type=${{ github.event.inputs.version_type }} -Pdebug=${{ github.event.inputs.debug }} ${{ join(matrix.args, ' ') }}
 
   update-description:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Checkout mcmeta
+        uses: actions/checkout@v6
+        with:
+          repository: uebliche/mcmeta
+          path: .mcmeta
 
       - name: Set up Java
         uses: actions/setup-java@v5
@@ -255,4 +268,5 @@ jobs:
       - name: Update Description
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
-        run: ./gradlew modrinthSyncBody -Pdebug=${{ github.event.inputs.debug }}
+          MCMETA_PLUGIN_PATH: ${{ github.workspace }}/.mcmeta/gradle-plugin
+        run: ./gradlew -Dorg.gradle.java.home="$JAVA_HOME" modrinthSyncBody -Pdebug=${{ github.event.inputs.debug }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -139,7 +139,8 @@ jobs:
           def version_at_least(ver: str, minimum: str):
               return parse_version(ver) >= parse_version(minimum)
 
-          data = json.loads(pathlib.Path("versions.matrix.json").read_text())
+          matrix_path = pathlib.Path("versions.matrix.json")
+          data = json.loads(matrix_path.read_text()) if matrix_path.exists() else {}
           matrix = []
 
           fabric_versions = []

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,7 +137,7 @@ jobs:
               return parts
 
           def version_at_least(ver: str, minimum: str):
-              return parse_version(ver) >= parse_version(minimum)
+              return ver.startswith("1.") and parse_version(ver) >= parse_version(minimum)
 
           matrix_path = pathlib.Path("versions.matrix.json")
           data = json.loads(matrix_path.read_text()) if matrix_path.exists() else {}
@@ -217,7 +217,7 @@ jobs:
           else
               TASKS=":loader-${LOADER}:build"
           fi
-          ./gradlew $TASKS -PmcVersion=$MC_VERSION -Ptag=$TAG -Pversion_type=$VERSION_TYPE -Pdebug=$DEBUG_FLAG $EXTRA_ARGS
+          ./gradlew -Dorg.gradle.java.home="$JAVA_HOME" $TASKS -PmcVersion=$MC_VERSION -Ptag=$TAG -Pversion_type=$VERSION_TYPE -Pdebug=$DEBUG_FLAG $EXTRA_ARGS
 
       - name: Upload jars to release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
               return parts
 
           def version_at_least(ver: str, minimum: str):
-              return parse_version(ver) >= parse_version(minimum)
+              return ver.startswith("1.") and parse_version(ver) >= parse_version(minimum)
 
           matrix_path = pathlib.Path("versions.matrix.json")
           data = json.loads(matrix_path.read_text()) if matrix_path.exists() else {}
@@ -90,4 +90,4 @@ jobs:
         run: chmod +x ./gradlew
       - name: Test Build
         run: |
-          ./gradlew :loader-${{ matrix.loader }}:build -PmcVersion=${{ matrix.mcVersion }} ${{ join(matrix.args, ' ') }}
+          ./gradlew -Dorg.gradle.java.home="$JAVA_HOME" :loader-${{ matrix.loader }}:build -PmcVersion=${{ matrix.mcVersion }} ${{ join(matrix.args, ' ') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,11 @@ jobs:
     name: Test ${{ matrix.loader }} ${{ matrix.mcVersion }}
     steps:
       - uses: actions/checkout@v6
+      - name: Checkout mcmeta
+        uses: actions/checkout@v6
+        with:
+          repository: uebliche/mcmeta
+          path: .mcmeta
       - name: Set up Java
         uses: actions/setup-java@v5
         with:
@@ -89,5 +94,7 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       - name: Test Build
+        env:
+          MCMETA_PLUGIN_PATH: ${{ github.workspace }}/.mcmeta/gradle-plugin
         run: |
           ./gradlew -Dorg.gradle.java.home="$JAVA_HOME" :loader-${{ matrix.loader }}:build -PmcVersion=${{ matrix.mcVersion }} ${{ join(matrix.args, ' ') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Build loader/version matrix
         id: set-matrix
         run: |
@@ -79,9 +79,9 @@ jobs:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     name: Test ${{ matrix.loader }} ${{ matrix.mcVersion }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,8 @@ jobs:
           def version_at_least(ver: str, minimum: str):
               return parse_version(ver) >= parse_version(minimum)
 
-          data = json.loads(pathlib.Path("versions.matrix.json").read_text())
+          matrix_path = pathlib.Path("versions.matrix.json")
+          data = json.loads(matrix_path.read_text()) if matrix_path.exists() else {}
           matrix = []
 
           # Fabric entries: derive from fabric list or fallback to explicit matrix file

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ manifold_plugin_version=0.0.2-alpha
 manifold_version=2025.1.25
 minecraft_version=1.21.10
 paper_mc_version=1.21.1
-buildFromVersion=1.17.0
+buildFromVersion=1.21
 
 # Mod Properties
 mod_id=modtemplate

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@
 org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 
-org.gradle.java.home=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home
 
 manifold_plugin_version=0.0.2-alpha
 manifold_version=2025.1.25

--- a/loader-fabric/build.gradle
+++ b/loader-fabric/build.gradle
@@ -462,4 +462,7 @@ dependencies {
     implementation project(':common')
 }
 
-apply from: rootProject.file("../../gradle/mod-devkit-local.gradle")
+def modDevkitLocal = rootProject.file("../../gradle/mod-devkit-local.gradle")
+if (modDevkitLocal.exists()) {
+    apply from: modDevkitLocal
+}

--- a/loader-neoforge/build.gradle
+++ b/loader-neoforge/build.gradle
@@ -248,4 +248,7 @@ tasks.withType(ProcessResources).configureEach {
     }
 }
 
-apply from: rootProject.file("../../gradle/mod-devkit-local.gradle")
+def modDevkitLocal = rootProject.file("../../gradle/mod-devkit-local.gradle")
+if (modDevkitLocal.exists()) {
+    apply from: modDevkitLocal
+}


### PR DESCRIPTION
## Summary
- replace stale broad #14 with a current-main scoped CI/workflow update
- update `actions/checkout` from v3 to v6
- update `actions/setup-java` from v3 to v5
- make the generated Minecraft version matrix tolerate a missing `versions.matrix.json`; current `main` already falls back to Fabric metadata, but read the optional file before the fallback could run
- remove the hard-coded local macOS `org.gradle.java.home` so CI uses the JDK provisioned by `setup-java`
- provide the mcmeta Gradle plugin in GitHub Actions and make the optional local mod-devkit include conditional

## Validation
- workflow YAML parse
- `git diff --check`
- matrix optional-file contract check
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew --no-daemon --version`
- `MCMETA_PLUGIN_PATH=/tmp/uebliche-mcmeta/gradle-plugin JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ./gradlew --no-daemon -Dorg.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64 :loader-fabric:build -PmcVersion=1.21.10 --stacktrace`

Supersedes #14, whose branch is dirty and includes broad unrelated historical changes.
